### PR TITLE
UI update, math and bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # macOS
 .DS_Store
 
+.vscode
+
 # Logs
 logs
 *.log

--- a/plugins/openshift/src/components/DeploymentsListComponent/DeploymentsListComponent.tsx
+++ b/plugins/openshift/src/components/DeploymentsListComponent/DeploymentsListComponent.tsx
@@ -224,12 +224,12 @@ export const DeploymentsListComponent = (data: any) => {
                 </TableCell>
                 <TableCell align="center">
                     <Typography align="center" variant="button">
-                        <Link href={`${data.environmentUrl}/${data.namespace}/deployments/${result.name}`} underline="hover">{result.name}</Link>
+                        <Link href={`${data.environmentUrl}/${data.namespace}/deployments/${result.name}`} underline="hover" target="_blank">{result.name}</Link>
                     </Typography>
                 </TableCell>
                 <TableCell align="center">
                     <Typography align="center" variant="button">
-                        <Link href={`https://${result.image}`} underline="hover">{formatImageLinkText(result.image)}</Link>
+                        <Link href={`https://${result.image}`} underline="hover"  target="_blank">{formatImageLinkText(result.image)}</Link>
                     </Typography>
                 </TableCell>
                 <TableCell style={{width:'10%'}} align="center">

--- a/plugins/openshift/src/components/DeploymentsListComponent/DeploymentsListComponent.tsx
+++ b/plugins/openshift/src/components/DeploymentsListComponent/DeploymentsListComponent.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect } from 'react';
 import {
+  Card,
+  CardContent,
   Grid,
   Link,
   Table,
@@ -270,9 +272,22 @@ export const DeploymentsListComponent = (data: any) => {
     return imageUrl.split('/').pop();
   };
 
-  const RowBody = ({ result }: { result: any }) => {
-    const tooltipContent = `Available pods: ${result.readyReplicas}, Desired pods: ${result.replicas}`;
+  const ToolTipContent = (result) => {
+    return (
+      <Card>
+        <CardContent>
+          <React.Fragment>
+            Available pods: {result.readyReplicas || 0}
+            <br />
+            Desired pods: {result.replicas}
+          </React.Fragment>
+        </CardContent>
+      </Card>
+    );
+  }
 
+  const RowBody = ({ result }: { result: any }) => {
+    const tooltipContent = ToolTipContent(result);
     return (
       <TableRow>
         <TableCell style={{ width: '8%' }} align="center">

--- a/plugins/openshift/src/components/DeploymentsListComponent/DeploymentsListComponent.tsx
+++ b/plugins/openshift/src/components/DeploymentsListComponent/DeploymentsListComponent.tsx
@@ -1,302 +1,392 @@
 import React from 'react';
 import {
-    Grid,
-    Link,
-    Table,
-    TableBody,
-    TableCell,
-    TableContainer,
-    TableHead,
-    TablePagination,
-    TableRow,
-    Typography } from '@material-ui/core';
-import {
-    InfoCard,
-} from '@backstage/core-components';
+  Grid,
+  Link,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TablePagination,
+  TableRow,
+  Typography,
+} from '@material-ui/core';
+import { InfoCard } from '@backstage/core-components';
 import { Tooltip } from '@patternfly/react-core';
 import { makeStyles } from '@material-ui/core/styles';
 import LinearProgress from '@material-ui/core/LinearProgress';
-import QueryOpenshift from '../../common/QueryOpenshiftAPI'
+import QueryOpenshift from '../../common/QueryOpenshiftAPI';
 import ResourceUsageProgress from './ResourceUsageProgress';
-import CheckCircle from "@patternfly/react-icons/dist/js/icons/check-circle-icon";
+import CheckCircle from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
-import TimesCircle from "@patternfly/react-icons/dist/js/icons/times-circle-icon";
+import TimesCircle from '@patternfly/react-icons/dist/js/icons/times-circle-icon';
 
 export const DeploymentsListComponent = (data: any) => {
-    const { result: OpenshiftResult, loaded: OpenshiftLoaded, error: OpenshiftError } = QueryOpenshift(data);
+  const {
+    result: OpenshiftResult,
+    loaded: OpenshiftLoaded,
+    error: OpenshiftError,
+  } = QueryOpenshift(data);
 
-    // table pagination
-    const [page, setPage] = React.useState(0);
-    const [rowsPerPage, setRowsPerPage] = React.useState(10);
-    const allDeploymentData: { name: any; readyReplicas: any; replicas: any; resourceUsage: { cpu: number; memory: number; }; resourceLimitsRequests: { requests: { cpu: number; memory: number; }; limits: { cpu: number; memory: number; }; }; creationTimestamp: any; image: any; }[] = [];
-
-    const useStyles = makeStyles((theme) => ({
-        root: {
-          width: '100%',
-          '& > * + *': {
-            marginTop: theme.spacing(2),
-          },
-        },
-    }));
-
-    const classes = useStyles();
-
-    const parseResourceValue = (value: string, resourceType: string) => {
-        const m = new RegExp("m");
-        const ki = new RegExp("Ki");
-        const mi = new RegExp("Mi");
-        const gi = new RegExp("Gi");
-
-        if (m.test(value)) {
-            // Convert millicores to cores
-            return parseFloat(value.replace('m', '')) / 1000;
-        } else if (ki.test(value)) {
-            if (resourceType === "cpu") {
-            // print error "Unsupported CPU value format: ${value}"
-            } else if (resourceType === "memory") {
-                // Convert KiB to MiB
-                return parseFloat(value.replace('Ki', '')) / 1024;
-            }
-        } else if (mi.test(value)) {
-            if (resourceType === "cpu") {
-                // print error "Unsupported CPU value format: ${value}"
-            } else if (resourceType === "memory") {
-                // Assume MiB for memory
-                return parseFloat(value.replace('Mi', ''));
-            }
-        } else if (gi.test(value)) {
-            if (resourceType === "cpu") {
-                // print error "Unsupported CPU value format: ${value}"
-            } else if (resourceType === "memory") {
-                // Convert GiB to MiB
-                return parseFloat(value.replace('Gi', '')) * 1024;
-            }
-        } else {
-            try {
-                const floatValue = parseFloat(value);
-                if (resourceType === "cpu") {
-                    // Assume cores for CPU
-                    return floatValue;
-                } else if (resourceType === "memory") {
-                    // Assume bytes and convert to MiB for memory
-                    return floatValue / (1024 * 1024);
-                }
-            } catch {
-                // error
-            }
-        }
-
-        return 0
-    }
-
-    const aggregate_pod_resources = (deploymentData: any) => {
-        const resourceInfo = {'requests': {'cpu': 0, 'memory': 0}, 'limits': {'cpu': 0, 'memory': 0}}
-        
-        Object.values(deploymentData).map(deployment => {
-            const resourceLimitsCPU = deployment.spec.template.spec.containers[0].resources.limits ? deployment?.spec?.template?.spec?.containers[0]?.resources?.limits?.cpu : 0;
-            const resourceLimitsMemory = deployment.spec.template.spec.containers[0].resources.limits ? deployment.spec.template.spec.containers[0].resources.limits.memory : 0;
-            const resourceRequestsCPU = deployment.spec.template.spec.containers[0].resources.requests ? deployment.spec.template.spec.containers[0].resources.requests.cpu : 0;
-            const resourceRequestsMemory = deployment.spec.template.spec.containers[0].resources.requests ? deployment.spec.template.spec.containers[0].resources.requests.memory : 0;
-            
-            resourceInfo.limits.cpu += parseResourceValue(resourceLimitsCPU, "cpu")
-            resourceInfo.limits.memory += parseResourceValue(resourceLimitsMemory, "memory")
-            resourceInfo.requests.cpu += parseResourceValue(resourceRequestsCPU, "cpu")
-            resourceInfo.requests.memory += parseResourceValue(resourceRequestsMemory, "memory")
-        })
-
-        return resourceInfo;
-    }
-
-    // // calculate the total resource utilization per pod
-    const sumCPUMemoryUsage = (deployment: any, deploymentData: any, podData: any) => {
-        const totalPodUsage = {'cpu': 0, 'memory': 0};
-
-        // Calculate pod cpu/memory usage alongside data from deployments
-        Object.values(podData).map(pod => {
-            if (pod.metadata.name.includes(deploymentData[deployment].metadata.name)) {
-                Object.values(pod.containers).forEach(container => {
-                    const cpuUsage = container.usage.cpu;
-                    const memoryUsage = container.usage.memory;
-
-                    totalPodUsage.cpu += parseResourceValue(cpuUsage, "cpu");
-                    totalPodUsage.memory += parseResourceValue(memoryUsage, "memory");
-                })
-            }
-        })
-
-        return totalPodUsage;
-    }
-    
-    // creates an object with each pod name and associated cpu and memory usage
-    const getDeploymentData = (data: any) => {
-        const deploymentData = data.deployments;
-        const podData = data.pods;
-
-        for (const deployment in deploymentData) {
-            const resourceInfo = aggregate_pod_resources(deploymentData)
-            const totalPodUsage = sumCPUMemoryUsage(deployment, deploymentData, podData)
-
-            allDeploymentData.push({
-                "name": deploymentData[deployment].metadata.name,
-                "readyReplicas": deploymentData[deployment].status.readyReplicas,
-                "replicas": deploymentData[deployment].status.replicas,
-                "resourceUsage": totalPodUsage,
-                "resourceLimitsRequests": resourceInfo,
-                "creationTimestamp": deploymentData[deployment].metadata.creationTimestamp,
-                "image": deploymentData[deployment].spec.template.spec.containers[0].image
-            });
-
-            console.log(allDeploymentData)
-        }
-
-        return allDeploymentData
-    }
-
-    getDeploymentData(OpenshiftResult)
-
-    // Validate that availableReplicas is greater than 0
-    const checkDeploymentStatus = (readyReplicas: any, replicas: any) => {
-        if (readyReplicas === 0) {
-            // Return red 'x'
-            return <TimesCircle color="#FF0000" />;
-        }
-
-        if (readyReplicas !== replicas) {
-            <ExclamationTriangleIcon color="#FFD700" />
-        }
-
-        // Return green checkmark
-        return <CheckCircle color="#00FF00" />
-    }
-
-    const formatDeploymentTime = (deployDateTime: any) => {
-        const formattedTime = deployDateTime.split('T')[1].replace(/Z/g, ' ');
-        const formattedDate = deployDateTime.split('T')[0].replace(/-/g, ' ');
-        const day = formattedDate.split(' ')[2]
-        const month = formattedDate.split(' ')[1]
-        const year = formattedDate.split(' ')[0]
-        
-        return `${month}/${day}/${year}, ${formattedTime}`
-    }
-
-    const handleChangePage = (
-        event: React.MouseEvent<HTMLButtonElement> | null,
-        newPage: number,
-    ) => {
-        setPage(newPage);
+  // table pagination
+  const [page, setPage] = React.useState(0);
+  const [rowsPerPage, setRowsPerPage] = React.useState(10);
+  const allDeploymentData: {
+    name: any;
+    readyReplicas: any;
+    replicas: any;
+    resourceUsage: { cpu: number; memory: number };
+    resourceLimitsRequests: {
+      requests: { cpu: number; memory: number };
+      limits: { cpu: number; memory: number };
     };
-    
-    const handleChangeRowsPerPage = (
-        event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
-    ) => {
-        setRowsPerPage(parseInt(event.target.value, 10));
-        setPage(page);
+    creationTimestamp: any;
+    image: any;
+  }[] = [];
+
+  const useStyles = makeStyles(theme => ({
+    root: {
+      width: '100%',
+      '& > * + *': {
+        marginTop: theme.spacing(2),
+      },
+    },
+  }));
+
+  const classes = useStyles();
+
+  const parseResourceValue = (value: string, resourceType: string) => {
+    const m = new RegExp('m');
+    const ki = new RegExp('Ki');
+    const mi = new RegExp('Mi');
+    const gi = new RegExp('Gi');
+
+    if (m.test(value)) {
+      // Convert millicores to cores
+      return parseFloat(value.replace('m', '')) / 1000;
+    } else if (ki.test(value)) {
+      if (resourceType === 'cpu') {
+        // print error "Unsupported CPU value format: ${value}"
+      } else if (resourceType === 'memory') {
+        // Convert KiB to MiB
+        return parseFloat(value.replace('Ki', '')) / 1024;
+      }
+    } else if (mi.test(value)) {
+      if (resourceType === 'cpu') {
+        // print error "Unsupported CPU value format: ${value}"
+      } else if (resourceType === 'memory') {
+        // Assume MiB for memory
+        return parseFloat(value.replace('Mi', ''));
+      }
+    } else if (gi.test(value)) {
+      if (resourceType === 'cpu') {
+        // print error "Unsupported CPU value format: ${value}"
+      } else if (resourceType === 'memory') {
+        // Convert GiB to MiB
+        return parseFloat(value.replace('Gi', '')) * 1024;
+      }
+    } else {
+      try {
+        const floatValue = parseFloat(value);
+        if (resourceType === 'cpu') {
+          // Assume cores for CPU
+          return floatValue;
+        } else if (resourceType === 'memory') {
+          // Assume bytes and convert to MiB for memory
+          return floatValue / (1024 * 1024);
+        }
+      } catch {
+        // error
+      }
+    }
+
+    return 0;
+  };
+
+  const aggregate_pod_resources = (deploymentData: any) => {
+    const resourceInfo = {
+      requests: { cpu: 0, memory: 0 },
+      limits: { cpu: 0, memory: 0 },
     };
 
-    const RowHead = () => {
-        return (
-            <TableHead>
-                <TableRow>
-                    <TableCell align="center"><Typography variant="button">Status</Typography></TableCell>
-                    <TableCell align="center"><Typography variant="button">Name</Typography></TableCell>
-                    <TableCell align="center"><Typography variant="button">Image Tag</Typography></TableCell>
-                    <TableCell align="center"><Typography variant="button">CPU</Typography></TableCell>
-                    <TableCell align="center"><Typography variant="button">Memory</Typography></TableCell>
-                    <TableCell align="center"><Typography variant="button">Last Deployment Time</Typography></TableCell>
-                </TableRow>
-            </TableHead>
-        )
+    Object.values(deploymentData).map(deployment => {
+      const resourceLimitsCPU = deployment.spec.template.spec.containers[0]
+        .resources.limits
+        ? deployment?.spec?.template?.spec?.containers[0]?.resources?.limits
+            ?.cpu
+        : 0;
+      const resourceLimitsMemory = deployment.spec.template.spec.containers[0]
+        .resources.limits
+        ? deployment.spec.template.spec.containers[0].resources.limits.memory
+        : 0;
+      const resourceRequestsCPU = deployment.spec.template.spec.containers[0]
+        .resources.requests
+        ? deployment.spec.template.spec.containers[0].resources.requests.cpu
+        : 0;
+      const resourceRequestsMemory = deployment.spec.template.spec.containers[0]
+        .resources.requests
+        ? deployment.spec.template.spec.containers[0].resources.requests.memory
+        : 0;
+
+      resourceInfo.limits.cpu += parseResourceValue(resourceLimitsCPU, 'cpu');
+      resourceInfo.limits.memory += parseResourceValue(
+        resourceLimitsMemory,
+        'memory',
+      );
+      resourceInfo.requests.cpu += parseResourceValue(
+        resourceRequestsCPU,
+        'cpu',
+      );
+      resourceInfo.requests.memory += parseResourceValue(
+        resourceRequestsMemory,
+        'memory',
+      );
+    });
+
+    return resourceInfo;
+  };
+
+  // // calculate the total resource utilization per pod
+  const sumCPUMemoryUsage = (
+    deployment: any,
+    deploymentData: any,
+    podData: any,
+  ) => {
+    const totalPodUsage = { cpu: 0, memory: 0 };
+
+    // Calculate pod cpu/memory usage alongside data from deployments
+    Object.values(podData).map(pod => {
+      if (
+        pod.metadata.name.includes(deploymentData[deployment].metadata.name)
+      ) {
+        Object.values(pod.containers).forEach(container => {
+          const cpuUsage = container.usage.cpu;
+          const memoryUsage = container.usage.memory;
+
+          totalPodUsage.cpu += parseResourceValue(cpuUsage, 'cpu');
+          totalPodUsage.memory += parseResourceValue(memoryUsage, 'memory');
+        });
+      }
+    });
+
+    return totalPodUsage;
+  };
+
+  // creates an object with each pod name and associated cpu and memory usage
+  const getDeploymentData = (data: any) => {
+    const deploymentData = data.deployments;
+    const podData = data.pods;
+
+    for (const deployment in deploymentData) {
+      const resourceInfo = aggregate_pod_resources(deploymentData);
+      const totalPodUsage = sumCPUMemoryUsage(
+        deployment,
+        deploymentData,
+        podData,
+      );
+
+      allDeploymentData.push({
+        name: deploymentData[deployment].metadata.name,
+        readyReplicas: deploymentData[deployment].status.readyReplicas,
+        replicas: deploymentData[deployment].status.replicas,
+        resourceUsage: totalPodUsage,
+        resourceLimitsRequests: resourceInfo,
+        creationTimestamp:
+          deploymentData[deployment].metadata.creationTimestamp,
+        image:
+          deploymentData[deployment].spec.template.spec.containers[0].image,
+      });
+
+      console.log(allDeploymentData);
     }
 
-    const formatImageLinkText = (imageUrl: string) => {
-        return imageUrl.split("/").pop()
+    return allDeploymentData;
+  };
+
+  getDeploymentData(OpenshiftResult);
+
+  // Validate that availableReplicas is greater than 0
+  const checkDeploymentStatus = (readyReplicas: any, replicas: any) => {
+    if (readyReplicas === 0) {
+      // Return red 'x'
+      return <TimesCircle color="#EE0000" />;
     }
 
-    const RowBody = ({ result }) => {
-        const tooltipContent = `Available pods: ${result.readyReplicas}, Desired pods: ${result.replicas}`;
-    
-        return (
-            <TableRow>
-                <TableCell style={{width:'8%'}} align="center">
-                    <Tooltip content={tooltipContent}>
-                        <Typography align="center" variant="button">{checkDeploymentStatus(result.readyReplicas, result.replicas)}</Typography>
-                    </Tooltip>
-                </TableCell>
-                <TableCell align="center">
-                    <Typography align="center" variant="button">
-                        <Link href={`${data.environmentUrl}/${data.namespace}/deployments/${result.name}`} underline="hover" target="_blank">{result.name}</Link>
-                    </Typography>
-                </TableCell>
-                <TableCell align="center">
-                    <Typography align="center" variant="button">
-                        <Link href={`https://${result.image}`} underline="hover"  target="_blank">{formatImageLinkText(result.image)}</Link>
-                    </Typography>
-                </TableCell>
-                <TableCell style={{width:'10%'}} align="center">
-                    <Typography align="center" variant="button">
-                        <ResourceUsageProgress resourceUsage={result.resourceUsage} resourceLimitsRequests={result.resourceLimitsRequests} resourceType="cpu" />
-                    </Typography>
-                </TableCell>
-                <TableCell style={{width:'10%'}} align="center">
-                    <Typography align="center" variant="button">
-                        <ResourceUsageProgress resourceUsage={result.resourceUsage} resourceLimitsRequests={result.resourceLimitsRequests} resourceType="memory" />
-                    </Typography>
-                </TableCell>
-                <TableCell align="center">
-                    <Typography align="center" variant="button">{formatDeploymentTime(result.creationTimestamp)}</Typography>
-                </TableCell>
-            </TableRow>
-        )
+    if (readyReplicas !== replicas) {
+      <ExclamationTriangleIcon color="#FFD700" />;
     }
 
-    const ShowTable = () => {
-        return (
-            <Table aria-label="simple table">
-                <RowHead />
-                <TableBody>
-                {(allDeploymentData.length > 0
-                    ? allDeploymentData.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
-                    : allDeploymentData
-                ).map((deployment) => (
-                        <RowBody result={deployment} />
-                ))}
-                </TableBody>
-            </Table>
-        )
-    }
+    // Return green checkmark
+    return <CheckCircle color="#00FF00" />;
+  };
 
-    if (OpenshiftError) {
-        return (
-            <InfoCard>
-                <Typography align="center" variant="button">
-                    Error retrieving data from Openshift cluster.
-                </Typography>
-            </InfoCard>
-        )
-    }
+  const formatDeploymentTime = (deployDateTime: any) => {
+    const formattedTime = deployDateTime.split('T')[1].replace(/Z/g, ' ');
+    const formattedDate = deployDateTime.split('T')[0].replace(/-/g, ' ');
+    const day = formattedDate.split(' ')[2];
+    const month = formattedDate.split(' ')[1];
+    const year = formattedDate.split(' ')[0];
 
-    if (!OpenshiftLoaded) {
-        return (
-            <InfoCard className={classes.root}>
-                <LinearProgress />
-            </InfoCard>
-        )
-    }
-    
+    return `${month}/${day}/${year}, ${formattedTime}`;
+  };
+
+  const handleChangePage = (
+    _event: React.MouseEvent<HTMLButtonElement> | null,
+    newPage: number,
+  ) => {
+    setPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = (
+    event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    setRowsPerPage(parseInt(event.target.value, 10));
+    setPage(page);
+  };
+
+  const RowHead = () => {
     return (
-        <Grid container spacing={3} direction="column">
-        <TableContainer>
-            <ShowTable />
-        </TableContainer>
-        <TablePagination
-            rowsPerPageOptions={[5, 10, 25]}
-            component="div"
-            count={allDeploymentData.length}
-            rowsPerPage={rowsPerPage}
-            page={page}
-            onPageChange={handleChangePage}
-            onRowsPerPageChange={handleChangeRowsPerPage}
-        />
-        </Grid>
-    )
-}
+      <TableHead>
+        <TableRow>
+          <TableCell align="center">
+            <Typography variant="button">Status</Typography>
+          </TableCell>
+          <TableCell align="center">
+            <Typography variant="button">Name</Typography>
+          </TableCell>
+          <TableCell align="center">
+            <Typography variant="button">Image Tag</Typography>
+          </TableCell>
+          <TableCell align="center">
+            <Typography variant="button">CPU</Typography>
+          </TableCell>
+          <TableCell align="center">
+            <Typography variant="button">Memory</Typography>
+          </TableCell>
+          <TableCell align="center">
+            <Typography variant="button">Last Deployment Time</Typography>
+          </TableCell>
+        </TableRow>
+      </TableHead>
+    );
+  };
+
+  const formatImageLinkText = (imageUrl: string) => {
+    return imageUrl.split('/').pop();
+  };
+
+  const RowBody = ({ result }: { result: any }) => {
+    const tooltipContent = `Available pods: ${result.readyReplicas}, Desired pods: ${result.replicas}`;
+
+    return (
+      <TableRow>
+        <TableCell style={{ width: '8%' }} align="center">
+          <Tooltip content={tooltipContent}>
+            <Typography align="center" variant="button">
+              {checkDeploymentStatus(result.readyReplicas, result.replicas)}
+            </Typography>
+          </Tooltip>
+        </TableCell>
+        <TableCell align="center">
+          <Typography align="center" variant="button">
+            <Link
+              href={`${data.environmentUrl}/${data.namespace}/deployments/${result.name}`}
+              underline="hover"
+              target="_blank"
+            >
+              {result.name}
+            </Link>
+          </Typography>
+        </TableCell>
+        <TableCell align="center">
+          <Typography align="center" variant="button">
+            <Link
+              href={`https://${result.image}`}
+              underline="hover"
+              target="_blank"
+            >
+              {formatImageLinkText(result.image)}
+            </Link>
+          </Typography>
+        </TableCell>
+        <TableCell style={{ width: '10%' }} align="center">
+          <Typography align="center" variant="button">
+            <ResourceUsageProgress
+              resourceUsage={result.resourceUsage}
+              resourceLimitsRequests={result.resourceLimitsRequests}
+              resourceType="cpu"
+            />
+          </Typography>
+        </TableCell>
+        <TableCell style={{ width: '10%' }} align="center">
+          <Typography align="center" variant="button">
+            <ResourceUsageProgress
+              resourceUsage={result.resourceUsage}
+              resourceLimitsRequests={result.resourceLimitsRequests}
+              resourceType="memory"
+            />
+          </Typography>
+        </TableCell>
+        <TableCell align="center">
+          <Typography align="center" variant="button">
+            {formatDeploymentTime(result.creationTimestamp)}
+          </Typography>
+        </TableCell>
+      </TableRow>
+    );
+  };
+
+  const ShowTable = () => {
+    return (
+      <Table aria-label="simple table">
+        <RowHead />
+        <TableBody>
+          {(allDeploymentData.length > 0
+            ? allDeploymentData.slice(
+                page * rowsPerPage,
+                page * rowsPerPage + rowsPerPage,
+              )
+            : allDeploymentData
+          ).map(deployment => (
+            <RowBody result={deployment} />
+          ))}
+        </TableBody>
+      </Table>
+    );
+  };
+
+  if (OpenshiftError) {
+    return (
+      <InfoCard>
+        <Typography align="center" variant="button">
+          Error retrieving data from Openshift cluster.
+        </Typography>
+      </InfoCard>
+    );
+  }
+
+  if (!OpenshiftLoaded) {
+    return (
+      <InfoCard className={classes.root}>
+        <LinearProgress />
+      </InfoCard>
+    );
+  }
+
+  return (
+    <Grid container spacing={3} direction="column">
+      <TableContainer>
+        <ShowTable />
+      </TableContainer>
+      <TablePagination
+        rowsPerPageOptions={[5, 10, 25]}
+        component="div"
+        count={allDeploymentData.length}
+        rowsPerPage={rowsPerPage}
+        page={page}
+        onPageChange={handleChangePage}
+        onRowsPerPageChange={handleChangeRowsPerPage}
+      />
+    </Grid>
+  );
+};

--- a/plugins/openshift/src/components/DeploymentsListComponent/DeploymentsListComponent.tsx
+++ b/plugins/openshift/src/components/DeploymentsListComponent/DeploymentsListComponent.tsx
@@ -197,7 +197,6 @@ export const DeploymentsListComponent = (data: any) => {
           deploymentData[deployment].spec.template.spec.containers[0].image,
       });
 
-      console.log(allDeploymentData);
     }
 
     return allDeploymentData;
@@ -347,8 +346,8 @@ export const DeploymentsListComponent = (data: any) => {
                 page * rowsPerPage + rowsPerPage,
               )
             : allDeploymentData
-          ).map(deployment => (
-            <RowBody result={deployment} />
+          ).map((deployment, index) => (
+            <RowBody result={deployment}  key={index}/>
           ))}
         </TableBody>
       </Table>

--- a/plugins/openshift/src/components/DeploymentsListComponent/DeploymentsListComponent.tsx
+++ b/plugins/openshift/src/components/DeploymentsListComponent/DeploymentsListComponent.tsx
@@ -27,8 +27,8 @@ export const DeploymentsListComponent = (data: any) => {
 
     // table pagination
     const [page, setPage] = React.useState(0);
-    const [rowsPerPage, setRowsPerPage] = React.useState(5);
-    const allDeploymentData = [];
+    const [rowsPerPage, setRowsPerPage] = React.useState(10);
+    const allDeploymentData: { name: any; readyReplicas: any; replicas: any; resourceUsage: { cpu: number; memory: number; }; resourceLimitsRequests: { requests: { cpu: number; memory: number; }; limits: { cpu: number; memory: number; }; }; creationTimestamp: any; image: any; }[] = [];
 
     const useStyles = makeStyles((theme) => ({
         root: {

--- a/plugins/openshift/src/components/DeploymentsListComponent/ResourceUsageProgress.tsx
+++ b/plugins/openshift/src/components/DeploymentsListComponent/ResourceUsageProgress.tsx
@@ -10,9 +10,6 @@ const ResourceUsageProgress = (resourceInfo: any) => {
   const requests = resourceInfo.resourceLimitsRequests.requests
     ? resourceInfo?.resourceLimitsRequests?.requests[resourceType]
     : 0;
-  const limits = resourceInfo.resourceLimitsRequests.limits
-    ? resourceInfo?.resourceLimitsRequests?.limits[resourceType]
-    : 0;
 
   // Bar color is green by default
   let barColor = '#228B22';

--- a/plugins/openshift/src/components/DeploymentsListComponent/ResourceUsageProgress.tsx
+++ b/plugins/openshift/src/components/DeploymentsListComponent/ResourceUsageProgress.tsx
@@ -5,73 +5,76 @@ import { Tooltip } from '@patternfly/react-core';
 import { Card, CardContent } from '@material-ui/core';
 
 const ResourceUsageProgress = (resourceInfo: any) => {
-    const resourceType = resourceInfo.resourceType;
-    const usage = resourceInfo.resourceUsage[resourceType];
-    const requests = resourceInfo.resourceLimitsRequests.requests ? resourceInfo?.resourceLimitsRequests?.requests[resourceType] : 0;
-    const limits = resourceInfo.resourceLimitsRequests.limits ? resourceInfo?.resourceLimitsRequests?.limits[resourceType] : 0;
-    const [canShowProgress, setCanShowProgress] = React.useState(false);
+  const resourceType = resourceInfo.resourceType;
+  const usage = resourceInfo.resourceUsage[resourceType];
+  const requests = resourceInfo.resourceLimitsRequests.requests
+    ? resourceInfo?.resourceLimitsRequests?.requests[resourceType]
+    : 0;
+  const limits = resourceInfo.resourceLimitsRequests.limits
+    ? resourceInfo?.resourceLimitsRequests?.limits[resourceType]
+    : 0;
+  const [canShowProgress, setCanShowProgress] = React.useState(false);
 
-    React.useEffect(() => {
-      setCanShowProgress(Number.isNaN(usage) || Number.isNaN(requests) || Number.isNaN(limits));
-    }, [usage, limits, requests]);
+  React.useEffect(() => {
+    setCanShowProgress(
+      Number.isNaN(usage) || Number.isNaN(requests) || Number.isNaN(limits),
+    );
+  }, [usage, limits, requests]);
 
-    // Validate that usage is below the resource limits
-    let barColor = "#228B22";
-    if (usage > requests) {
-      barColor = usage > limits * 0.8 ? "#EE0000" : "#FFD700";
+  // Validate that usage is below the resource limits
+  let barColor = '#228B22';
+  if (usage > requests) {
+    barColor = usage > limits * 0.8 ? '#EE0000' : '#FFD700';
+  }
+
+  const BorderLinearProgress = withStyles(theme => ({
+    root: {
+      height: 10,
+      borderRadius: 5,
+    },
+    colorPrimary: {
+      backgroundColor:
+        theme.palette.grey[theme.palette.type === 'light' ? 200 : 700],
+    },
+    bar: {
+      borderRadius: 5,
+      backgroundColor: barColor,
+    },
+  }))(LinearProgress);
+
+  const usagePercentageOfRequests = Math.min((usage / requests) * 100, 100);
+
+  const formatResourceValue = (value: number) => {
+    if (resourceInfo.resourceType === 'memory') {
+      return `${(value / 1024).toFixed(4)} GB`;
     }
-
-    const BorderLinearProgress = withStyles((theme) => ({
-      root: {
-        height: 10,
-        borderRadius: 5,
-      },
-      colorPrimary: {
-        backgroundColor: theme.palette.grey[theme.palette.type === 'light' ? 200 : 700],
-      },
-      bar: {
-        borderRadius: 5,
-        backgroundColor: barColor,
-      },
-    }))(LinearProgress);
-
-    // Clamp this value at a max of 100
-    const percentage = Math.min((usage / limits) * 100, 100);
-
-    const usagePercentageOfRequests = (usage / requests) * 100;
-    const usagePercentageOfLimits = (usage / limits) * 100;
-
-    const formatResourceValue = (value: number) => {
-      if (resourceInfo.resourceType === 'memory') {
-        return `${(value / 1024).toFixed(4)} GB`;
-      }
-      return `${value.toFixed(4)} cores`;
-    };
+    return `${value.toFixed(4)} cores`;
+  };
 
   const ToolTipContent = () => {
     return (
       <Card>
         <CardContent>
-        <React.Fragment>
-        Usage: {formatResourceValue(usage)} ({usagePercentageOfLimits.toFixed(2)}% of limits, {usagePercentageOfRequests.toFixed(2)}% of requests)
-        <br />
-        Requests: {formatResourceValue(requests)}
-        <br />
-        Limits: {formatResourceValue(limits)}
-      </React.Fragment>
+          <React.Fragment>
+            Requested: {formatResourceValue(requests)}
+            <br />
+            Used: {formatResourceValue(usage)}
+          </React.Fragment>
         </CardContent>
       </Card>
+    );
+  };
 
-    )
-  }
-  
-    return (
-        <React.Fragment>
-          <Tooltip content={<ToolTipContent/>} >
-            <BorderLinearProgress variant="determinate" value={percentage} />
-          </Tooltip>
-        </ React.Fragment>
-    )
-}
+  return (
+    <React.Fragment>
+      <Tooltip content={<ToolTipContent />}>
+        <BorderLinearProgress
+          variant="determinate"
+          value={usagePercentageOfRequests}
+        />
+      </Tooltip>
+    </React.Fragment>
+  );
+};
 
 export default ResourceUsageProgress;

--- a/plugins/openshift/src/components/DeploymentsListComponent/ResourceUsageProgress.tsx
+++ b/plugins/openshift/src/components/DeploymentsListComponent/ResourceUsageProgress.tsx
@@ -13,18 +13,16 @@ const ResourceUsageProgress = (resourceInfo: any) => {
   const limits = resourceInfo.resourceLimitsRequests.limits
     ? resourceInfo?.resourceLimitsRequests?.limits[resourceType]
     : 0;
-  const [canShowProgress, setCanShowProgress] = React.useState(false);
 
-  React.useEffect(() => {
-    setCanShowProgress(
-      Number.isNaN(usage) || Number.isNaN(requests) || Number.isNaN(limits),
-    );
-  }, [usage, limits, requests]);
-
-  // Validate that usage is below the resource limits
+  // Bar color is green by default
   let barColor = '#228B22';
-  if (usage > requests) {
-    barColor = usage > limits * 0.8 ? '#EE0000' : '#FFD700';
+  // If usage is greater than 60% of the requests, but less than 90 make it yellow
+  if (usage > requests * 0.6 && usage < requests * 0.9) {
+    barColor = '#FFD700';
+  }
+  //if the usage is greater than 90% of the requests, make it red
+  if (usage > requests * 0.9) {
+    barColor = '#EE0000';
   }
 
   const BorderLinearProgress = withStyles(theme => ({

--- a/plugins/openshift/src/components/DeploymentsListComponent/ResourceUsageProgress.tsx
+++ b/plugins/openshift/src/components/DeploymentsListComponent/ResourceUsageProgress.tsx
@@ -41,9 +41,9 @@ const ResourceUsageProgress = (resourceInfo: any) => {
 
   const formatResourceValue = (value: number) => {
     if (resourceInfo.resourceType === 'memory') {
-      return `${(value / 1024).toFixed(4)} GB`;
+      return `${value.toFixed(2)} Mi`;
     }
-    return `${value.toFixed(4)} cores`;
+    return `${value.toFixed(2)} cores`;
   };
 
   const ToolTipContent = () => {

--- a/plugins/openshift/src/components/DeploymentsListComponent/ResourceUsageProgress.tsx
+++ b/plugins/openshift/src/components/DeploymentsListComponent/ResourceUsageProgress.tsx
@@ -33,12 +33,13 @@ const ResourceUsageProgress = (resourceInfo: any) => {
       },
     }))(LinearProgress);
 
-    const percentage = (usage / limits) * 100;
+    // Clamp this value at a max of 100
+    const percentage = Math.min((usage / limits) * 100, 100);
+
     const usagePercentageOfRequests = (usage / requests) * 100;
     const usagePercentageOfLimits = (usage / limits) * 100;
-    console.log(percentage)
 
-    const formatResourceValue = (value) => {
+    const formatResourceValue = (value: number) => {
       if (resourceInfo.resourceType === 'memory') {
         return `${(value / 1024).toFixed(4)} GB`;
       }

--- a/plugins/openshift/src/components/DeploymentsListComponent/ResourceUsageProgress.tsx
+++ b/plugins/openshift/src/components/DeploymentsListComponent/ResourceUsageProgress.tsx
@@ -18,7 +18,7 @@ const ResourceUsageProgress = (resourceInfo: any) => {
     // Validate that usage is below the resource limits
     let barColor = "#228B22";
     if (usage > requests) {
-      barColor = usage > limits * 0.8 ? "#B22222" : "#FFD700";
+      barColor = usage > limits * 0.8 ? "#EE0000" : "#FFD700";
     }
 
     const BorderLinearProgress = withStyles((theme) => ({

--- a/plugins/openshift/src/components/DeploymentsListComponent/ResourceUsageProgress.tsx
+++ b/plugins/openshift/src/components/DeploymentsListComponent/ResourceUsageProgress.tsx
@@ -2,16 +2,18 @@ import React from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import LinearProgress from '@material-ui/core/LinearProgress';
 import { Tooltip } from '@patternfly/react-core';
+import { Card, CardContent } from '@material-ui/core';
 
 const ResourceUsageProgress = (resourceInfo: any) => {
     const resourceType = resourceInfo.resourceType;
     const usage = resourceInfo.resourceUsage[resourceType];
     const requests = resourceInfo.resourceLimitsRequests.requests ? resourceInfo?.resourceLimitsRequests?.requests[resourceType] : 0;
     const limits = resourceInfo.resourceLimitsRequests.limits ? resourceInfo?.resourceLimitsRequests?.limits[resourceType] : 0;
+    const [canShowProgress, setCanShowProgress] = React.useState(false);
 
-    console.log(`${resourceType} Usage: ${resourceInfo.resourceUsage[resourceType]}`)
-    console.log(`${resourceType} Limits: ${resourceInfo?.resourceLimitsRequests?.limits[resourceType]}`)
-    console.log(`${resourceType} Requests: ${resourceInfo?.resourceLimitsRequests?.requests[resourceType]}`)
+    React.useEffect(() => {
+      setCanShowProgress(Number.isNaN(usage) || Number.isNaN(requests) || Number.isNaN(limits));
+    }, [usage, limits, requests]);
 
     // Validate that usage is below the resource limits
     let barColor = "#228B22";
@@ -46,15 +48,26 @@ const ResourceUsageProgress = (resourceInfo: any) => {
       return `${value.toFixed(4)} cores`;
     };
 
-    const tooltipContent = `
-    Usage: ${formatResourceValue(usage)} (${usagePercentageOfLimits.toFixed(2)}% of limits, ${usagePercentageOfRequests.toFixed(2)}% of requests)
-    Requests: ${formatResourceValue(requests)}
-    Limits: ${formatResourceValue(limits)}
-  `;
+  const ToolTipContent = () => {
+    return (
+      <Card>
+        <CardContent>
+        <React.Fragment>
+        Usage: {formatResourceValue(usage)} ({usagePercentageOfLimits.toFixed(2)}% of limits, {usagePercentageOfRequests.toFixed(2)}% of requests)
+        <br />
+        Requests: {formatResourceValue(requests)}
+        <br />
+        Limits: {formatResourceValue(limits)}
+      </React.Fragment>
+        </CardContent>
+      </Card>
 
+    )
+  }
+  
     return (
         <React.Fragment>
-          <Tooltip content={tooltipContent}>
+          <Tooltip content={<ToolTipContent/>} >
             <BorderLinearProgress variant="determinate" value={percentage} />
           </Tooltip>
         </ React.Fragment>

--- a/plugins/openshift/src/components/OpenshiftComponent/OpenshiftComponent.tsx
+++ b/plugins/openshift/src/components/OpenshiftComponent/OpenshiftComponent.tsx
@@ -1,7 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import {
-  Button,
-  ButtonGroup,
   FormControl,
   Grid,
   InputLabel,
@@ -12,14 +10,28 @@ import {
 import { InfoCard } from '@backstage/core-components';
 import QueryQontract from '../../common/QueryAppInterface';
 import {
-  createTheme,
   makeStyles,
-  ThemeProvider,
 } from '@material-ui/core/styles';
 import LinearProgress from '@material-ui/core/LinearProgress';
 import { NSQuery } from './query';
 
 import { DeploymentsListComponent } from '../DeploymentsListComponent/DeploymentsListComponent';
+
+const clusterMap = {
+  // crc-eph is only used for testing purposes
+  'crc-eph': {
+    url: `https://console-openshift-console.apps.crc-eph.r9lp.p1.openshiftapps.com/k8s/ns`,
+    name: 'ephemeral',
+  },
+  crcs02ue1: {
+    url: `https://console-openshift-console.apps.crcs02ue1.urby.p1.openshiftapps.com/k8s/ns`,
+    name: 'stage',
+  },
+  crcp01ue1: {
+    url: `https://console-openshift-console.apps.crcp01ue1.o9m8.p1.openshiftapps.com/k8s/ns`,
+    name: 'prod',
+  },
+};
 
 export const OpenshiftComponent = () => {
   const {
@@ -28,40 +40,17 @@ export const OpenshiftComponent = () => {
     error: qontractError,
   } = QueryQontract(NSQuery);
 
-  console.log(qontractResult);
-
-  // state variables for stage/prod buttons
-  const [isStageButtonDisabled, setIsStageButtonDisabled] =
-    useState<boolean>(true);
-  const [isProdButtonDisabled, setIsProdButtonDisabled] =
-    useState<boolean>(false);
   const [currentEnvironment, setCurrentEnvironment] = useState<string>('');
   const [currentEnvironmentUrl, setCurrentEnvironmentUrl] =
     useState<string>('');
 
   const getEnvironmentNamespace = (environment: string) => {
-    const clusterInfo = qontractResult.find(e =>
+    const clusterInfo = qontractResult.find((e: { path: string | string[]; }) =>
       e.path.includes(`${environment}.yml`),
     );
     const namespaceName = clusterInfo?.name;
 
     return namespaceName;
-  };
-
-  const clusterMap = {
-    // crc-eph is only used for testing purposes
-    'crc-eph': {
-      url: `https://console-openshift-console.apps.crc-eph.r9lp.p1.openshiftapps.com/k8s/ns`,
-      name: 'ephemeral',
-    },
-    crcs02ue1: {
-      url: `https://console-openshift-console.apps.crcs02ue1.urby.p1.openshiftapps.com/k8s/ns`,
-      name: 'stage',
-    },
-    crcp01ue1: {
-      url: `https://console-openshift-console.apps.crcp01ue1.o9m8.p1.openshiftapps.com/k8s/ns`,
-      name: 'prod',
-    },
   };
 
   const getClusterName = (cluster: string) => {
@@ -98,32 +87,7 @@ export const OpenshiftComponent = () => {
     },
   }));
 
-  const theme = createTheme({
-    palette: {
-      action: {
-        disabledBackground: '#191970',
-        disabled: 'set color of text here',
-      },
-    },
-  });
-
   const classes = useStyles();
-
-  const buttonHandler = (isStageDisabled: boolean, isProdDisabled: boolean) => {
-    setIsStageButtonDisabled(isStageDisabled);
-    setIsProdButtonDisabled(isProdDisabled);
-
-    setCurrentEnvironment(
-      isProdButtonDisabled
-        ? getClusterName('crcs02ue1')
-        : getClusterName('crcp01ue1'),
-    );
-    setCurrentEnvironmentUrl(
-      isProdButtonDisabled
-        ? getClusterUrl('crcs02ue1')
-        : getClusterUrl('crcp01ue1'),
-    );
-  };
 
   const ClusterSelect = () => {
     return (
@@ -166,7 +130,6 @@ export const OpenshiftComponent = () => {
   useEffect(() => {
     const currentClusterName = getClusterName('crcs02ue1');
     const currentClusterUrl = getClusterUrl('crcs02ue1');
-
     setCurrentEnvironment(currentClusterName);
     setCurrentEnvironmentUrl(currentClusterUrl);
   }, []);

--- a/plugins/openshift/src/components/OpenshiftComponent/OpenshiftComponent.tsx
+++ b/plugins/openshift/src/components/OpenshiftComponent/OpenshiftComponent.tsx
@@ -1,145 +1,203 @@
 import React, { useEffect, useState } from 'react';
 import {
-    Button,
-    ButtonGroup,
-    Typography } from '@material-ui/core';
+  Button,
+  ButtonGroup,
+  FormControl,
+  Grid,
+  InputLabel,
+  MenuItem,
+  Select,
+  Typography,
+} from '@material-ui/core';
+import { InfoCard } from '@backstage/core-components';
+import QueryQontract from '../../common/QueryAppInterface';
 import {
-    InfoCard,
-} from '@backstage/core-components';
-import QueryQontract from '../../common/QueryAppInterface'
-import { createTheme, makeStyles, ThemeProvider } from '@material-ui/core/styles';
+  createTheme,
+  makeStyles,
+  ThemeProvider,
+} from '@material-ui/core/styles';
 import LinearProgress from '@material-ui/core/LinearProgress';
 import { NSQuery } from './query';
 
 import { DeploymentsListComponent } from '../DeploymentsListComponent/DeploymentsListComponent';
 
 export const OpenshiftComponent = () => {
-    const { result: qontractResult, loaded: qontractLoaded, error: qontractError } = QueryQontract(NSQuery);
+  const {
+    result: qontractResult,
+    loaded: qontractLoaded,
+    error: qontractError,
+  } = QueryQontract(NSQuery);
 
-    console.log(qontractResult)
+  console.log(qontractResult);
 
-    // state variables for stage/prod buttons
-    const [isStageButtonDisabled, setIsStageButtonDisabled] = useState<boolean>(true);
-    const [isProdButtonDisabled, setIsProdButtonDisabled] = useState<boolean>(false);
-    const [currentEnvironment, setCurrentEnvironment] = useState<string>("")
-    const [currentEnvironmentUrl, setCurrentEnvironmentUrl] = useState<string>("")
+  // state variables for stage/prod buttons
+  const [isStageButtonDisabled, setIsStageButtonDisabled] =
+    useState<boolean>(true);
+  const [isProdButtonDisabled, setIsProdButtonDisabled] =
+    useState<boolean>(false);
+  const [currentEnvironment, setCurrentEnvironment] = useState<string>('');
+  const [currentEnvironmentUrl, setCurrentEnvironmentUrl] =
+    useState<string>('');
 
-    const getEnvironmentNamespace = (environment: string) => {
-        const clusterInfo = qontractResult.find(e => e.path.includes(`${environment}.yml`))
-        const namespaceName = clusterInfo?.name
+  const getEnvironmentNamespace = (environment: string) => {
+    const clusterInfo = qontractResult.find(e =>
+      e.path.includes(`${environment}.yml`),
+    );
+    const namespaceName = clusterInfo?.name;
 
-        return namespaceName
+    return namespaceName;
+  };
+
+  const clusterMap = {
+    // crc-eph is only used for testing purposes
+    'crc-eph': {
+      url: `https://console-openshift-console.apps.crc-eph.r9lp.p1.openshiftapps.com/k8s/ns`,
+      name: 'ephemeral',
+    },
+    crcs02ue1: {
+      url: `https://console-openshift-console.apps.crcs02ue1.urby.p1.openshiftapps.com/k8s/ns`,
+      name: 'stage',
+    },
+    crcp01ue1: {
+      url: `https://console-openshift-console.apps.crcp01ue1.o9m8.p1.openshiftapps.com/k8s/ns`,
+      name: 'prod',
+    },
+  };
+
+  const getClusterName = (cluster: string) => {
+    if (clusterMap[cluster as keyof typeof clusterMap]) {
+      return clusterMap[cluster as keyof typeof clusterMap].name;
     }
+    return cluster;
+  };
 
-    const clusterMap = {
-        // crc-eph is only used for testing purposes
-        'crc-eph': {
-            url: `https://console-openshift-console.apps.crc-eph.r9lp.p1.openshiftapps.com/k8s/ns`,
-            name: 'ephemeral',
-        },
-        crcs02ue1: {
-            url: `https://console-openshift-console.apps.crcs02ue1.urby.p1.openshiftapps.com/k8s/ns`,
-            name: 'stage',
-        },
-        crcp01ue1: {
-            url: `https://console-openshift-console.apps.crcp01ue1.o9m8.p1.openshiftapps.com/k8s/ns`,
-            name: 'prod',
-        },
-    };
-
-    const getClusterName = (cluster: string) => {
-        if (clusterMap[cluster as keyof typeof clusterMap]) {
-            return clusterMap[cluster as keyof typeof clusterMap].name;
-        }
-        return cluster;
-    };
-
-    const getClusterUrl = (cluster: string) => {
-        if (clusterMap[cluster as keyof typeof clusterMap]) {
-            return clusterMap[cluster as keyof typeof clusterMap].url;
-        }
-        return cluster;
-    };
-    const capitalizeFirstLetter = (currentEnvironment: string) => {
-        return currentEnvironment.charAt(0).toUpperCase() + currentEnvironment.slice(1);
+  const getClusterUrl = (cluster: string) => {
+    if (clusterMap[cluster as keyof typeof clusterMap]) {
+      return clusterMap[cluster as keyof typeof clusterMap].url;
     }
-
-    const title: string = `${capitalizeFirstLetter(currentEnvironment)} Deployments`;
-    const namespaceName = getEnvironmentNamespace(currentEnvironment)
-
-    // styles for linear progress bar
-    const useStyles = makeStyles((theme) => ({
-        root: {
-          width: '100%',
-          '& > * + *': {
-            marginTop: theme.spacing(2),
-          },
-        },
-    }));
-
-    const theme = createTheme({
-        palette: {
-          action: {
-            disabledBackground: '#191970',
-            disabled: 'set color of text here'
-          }
-        }
-      }
-    )
-
-    const classes = useStyles();
-
-    const buttonHandler = (isStageDisabled: boolean, isProdDisabled: boolean) => {
-        setIsStageButtonDisabled(isStageDisabled)
-        setIsProdButtonDisabled(isProdDisabled)
-
-        setCurrentEnvironment(isProdButtonDisabled ? getClusterName('crcs02ue1') : getClusterName('crcp01ue1'))
-        setCurrentEnvironmentUrl(isProdButtonDisabled ? getClusterUrl('crcs02ue1') : getClusterUrl('crcp01ue1'))
-    }
-
-    const ClusterButtons = () => {
-        return (
-            <ThemeProvider theme={theme}>
-                <Button size="small" variant="contained" color="primary" onClick={() => buttonHandler(true, false)} disabled={isStageButtonDisabled}>Stage</Button>
-                <Button size="small" variant="contained" color="primary" onClick={() => buttonHandler(false, true)} disabled={isProdButtonDisabled}>Prod</Button>
-            </ThemeProvider>
-        );
-    }
-
-    // On page load set the current cluster to stage
-    useEffect(() => {
-        const currentClusterName = getClusterName('crcs02ue1')
-        const currentClusterUrl = getClusterUrl('crcs02ue1')
-
-        setCurrentEnvironment(currentClusterName)
-        setCurrentEnvironmentUrl(currentClusterUrl)
-    }, [])
-
-    if (qontractError) {
-        return (
-            <InfoCard>
-                <Typography align="center" variant="body1">
-                    Error retrieving data from qontract.
-                </Typography>
-            </InfoCard>
-        )
-    }
-
-    if (!qontractLoaded) {
-        return (
-            <InfoCard className={classes.root} title={title}>
-                <LinearProgress />
-            </InfoCard>
-        )
-    }
-
+    return cluster;
+  };
+  const capitalizeFirstLetter = (currentEnvironment: string) => {
     return (
-        <InfoCard title={title}>
-            <div style={{marginBottom: '20px'}}>
-                <ClusterButtons />
-            </div>
-            <DeploymentsListComponent key={currentEnvironment} environmentName={currentEnvironment} namespace={namespaceName} environmentUrl={currentEnvironmentUrl} qontractResult={qontractResult} />
-            
-        </InfoCard>
-    )
-}
+      currentEnvironment.charAt(0).toUpperCase() + currentEnvironment.slice(1)
+    );
+  };
+
+  const title: string = `${capitalizeFirstLetter(
+    currentEnvironment,
+  )} Deployments`;
+  const namespaceName = getEnvironmentNamespace(currentEnvironment);
+
+  // styles for linear progress bar
+  const useStyles = makeStyles(theme => ({
+    root: {
+      width: '100%',
+      '& > * + *': {
+        marginTop: theme.spacing(2),
+      },
+    },
+  }));
+
+  const theme = createTheme({
+    palette: {
+      action: {
+        disabledBackground: '#191970',
+        disabled: 'set color of text here',
+      },
+    },
+  });
+
+  const classes = useStyles();
+
+  const buttonHandler = (isStageDisabled: boolean, isProdDisabled: boolean) => {
+    setIsStageButtonDisabled(isStageDisabled);
+    setIsProdButtonDisabled(isProdDisabled);
+
+    setCurrentEnvironment(
+      isProdButtonDisabled
+        ? getClusterName('crcs02ue1')
+        : getClusterName('crcp01ue1'),
+    );
+    setCurrentEnvironmentUrl(
+      isProdButtonDisabled
+        ? getClusterUrl('crcs02ue1')
+        : getClusterUrl('crcp01ue1'),
+    );
+  };
+
+  const ClusterSelect = () => {
+    return (
+      <FormControl>
+        <InputLabel id="cluster-select-label">Cluster</InputLabel>
+        <Select
+          labelId="cluster-select-label"
+          id="cluster-select"
+          value={currentEnvironment}
+          onChange={e => {
+            setCurrentEnvironment(e.target.value as string);
+            setCurrentEnvironmentUrl(
+              e.target.value === 'stage'
+                ? getClusterUrl('crcs02ue1')
+                : getClusterUrl('crcp01ue1'),
+            );
+          }}
+        >
+          <MenuItem value={'stage'}>Stage</MenuItem>
+          <MenuItem value={'prod'}>Prod</MenuItem>
+        </Select>
+      </FormControl>
+    );
+  };
+
+  const InfoCardTitle = () => {
+    return (
+      <Grid container direction="row">
+        <Grid item xs={11}>
+          {title}
+        </Grid>
+        <Grid item xs={1}>
+          <ClusterSelect />
+        </Grid>
+      </Grid>
+    );
+  };
+
+  // On page load set the current cluster to stage
+  useEffect(() => {
+    const currentClusterName = getClusterName('crcs02ue1');
+    const currentClusterUrl = getClusterUrl('crcs02ue1');
+
+    setCurrentEnvironment(currentClusterName);
+    setCurrentEnvironmentUrl(currentClusterUrl);
+  }, []);
+
+  if (qontractError) {
+    return (
+      <InfoCard>
+        <Typography align="center" variant="body1">
+          Error retrieving data from qontract.
+        </Typography>
+      </InfoCard>
+    );
+  }
+
+  if (!qontractLoaded) {
+    return (
+      <InfoCard className={classes.root} title={title}>
+        <LinearProgress />
+      </InfoCard>
+    );
+  }
+
+  return (
+    <InfoCard title={<InfoCardTitle />}>
+      <DeploymentsListComponent
+        key={currentEnvironment}
+        environmentName={currentEnvironment}
+        namespace={namespaceName}
+        environmentUrl={currentEnvironmentUrl}
+        qontractResult={qontractResult}
+      />
+    </InfoCard>
+  );
+};

--- a/plugins/openshift/src/components/OpenshiftComponent/OpenshiftComponent.tsx
+++ b/plugins/openshift/src/components/OpenshiftComponent/OpenshiftComponent.tsx
@@ -64,7 +64,7 @@ export const OpenshiftComponent = () => {
         return currentEnvironment.charAt(0).toUpperCase() + currentEnvironment.slice(1);
     }
 
-    const title: string = `Deployment Information - ${capitalizeFirstLetter(currentEnvironment)} cluster`;
+    const title: string = `${capitalizeFirstLetter(currentEnvironment)} Deployments`;
     const namespaceName = getEnvironmentNamespace(currentEnvironment)
 
     // styles for linear progress bar


### PR DESCRIPTION
This patch does a few different things. Its change set got a bit large which I apologize for, the scope of the work grew as I encountered stuff:

* Change the cluster selection to a drop down and move it to the right
* Default to to 10 rows per page
* Make links open in a new tab
* Remove limits from all math and UI because they aren't universally present
* Make the popovers more legible with a background panel
* Fixed bugs in the math for how the requests and usage were being summed
* Fixed various bugs like code that should be in side effects that wasn't, things that should be reactive state that weren't, etc

