### PR TITLE
Fix bug where requests are undefined breaks UI

### DIFF
--- a/plugins/openshift/package.json
+++ b/plugins/openshift/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redhatinsights/backstage-plugin-openshift",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/openshift/src/components/DeploymentsListComponent/DeploymentsListComponent.tsx
+++ b/plugins/openshift/src/components/DeploymentsListComponent/DeploymentsListComponent.tsx
@@ -113,13 +113,20 @@ export const DeploymentsListComponent = (data: any) => {
 
   const sumRequests = (deployment: any) => {
     const resourceInfo = {
-      requests: { cpu: 0, memory: 0 },
-      limits: { cpu: 0, memory: 0 },
+      requests: { cpu: 0, memory: 0, undefined: false },
+      limits: { cpu: 0, memory: 0, undefined: false },
     };
       const replicas = deployment.spec.replicas || 1;
       deployment.spec.template.spec.containers.forEach((container: any) => {
-        const cpuRequests = container.resources.requests.cpu  || "0m"
-        const memoryRequests = container.resources.requests.memory  || "0Mi"
+        //if ( Object.keys(container.resources).length === 0) {
+        //  debugger
+        //}
+
+        const undefined = "UNDEFINED"
+        const cpuRequests = container.resources?.requests?.cpu  || undefined
+        const memoryRequests = container.resources?.requests?.memory  || undefined
+        
+        resourceInfo.requests.undefined = memoryRequests === undefined || cpuRequests === undefined;
         resourceInfo.requests.cpu += parseResourceValue(
           cpuRequests,
           'cpu',

--- a/plugins/openshift/src/components/DeploymentsListComponent/DeploymentsListComponent.tsx
+++ b/plugins/openshift/src/components/DeploymentsListComponent/DeploymentsListComponent.tsx
@@ -118,10 +118,6 @@ export const DeploymentsListComponent = (data: any) => {
     };
       const replicas = deployment.spec.replicas || 1;
       deployment.spec.template.spec.containers.forEach((container: any) => {
-        //if ( Object.keys(container.resources).length === 0) {
-        //  debugger
-        //}
-
         const undefined = "UNDEFINED"
         const cpuRequests = container.resources?.requests?.cpu  || undefined
         const memoryRequests = container.resources?.requests?.memory  || undefined

--- a/plugins/openshift/src/components/DeploymentsListComponent/ResourceUsageProgress.tsx
+++ b/plugins/openshift/src/components/DeploymentsListComponent/ResourceUsageProgress.tsx
@@ -2,11 +2,18 @@ import React from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import LinearProgress from '@material-ui/core/LinearProgress';
 import { Tooltip } from '@patternfly/react-core';
-import { Card, CardContent } from '@material-ui/core';
+import { Card, CardContent, Typography } from '@material-ui/core';
 
 const ResourceUsageProgress = (resourceInfo: any) => {
   const resourceType = resourceInfo.resourceType;
   const usage = resourceInfo.resourceUsage[resourceType];
+
+  const isUndefined = resourceInfo.resourceLimitsRequests.requests.undefined
+
+  if (isUndefined) {
+    return <Typography variant="button">Requests undefined</Typography>;
+  }
+
   const requests = resourceInfo.resourceLimitsRequests.requests
     ? resourceInfo?.resourceLimitsRequests?.requests[resourceType]
     : 0;
@@ -45,6 +52,9 @@ const ResourceUsageProgress = (resourceInfo: any) => {
     }
     return `${value.toFixed(2)} cores`;
   };
+
+  
+
 
   const ToolTipContent = () => {
     return (


### PR DESCRIPTION
Right now, if the requests aren't defined the UI bombs out. This adds a new check for undefined requests and sets the progress bar not to render if so