### PR TITLE
convert nanocores to cores

### DIFF
--- a/plugins/openshift/src/components/DeploymentsListComponent/ResourceUsageProgress.tsx
+++ b/plugins/openshift/src/components/DeploymentsListComponent/ResourceUsageProgress.tsx
@@ -59,7 +59,6 @@ const ResourceUsageProgress = (resourceInfo: any) => {
     if (resourceInfo.resourceType === 'memory') {
       return `${value.toFixed(2)} Mi`;
     }
-    
     return `${value} cores`;
   };
 

--- a/plugins/openshift/src/components/DeploymentsListComponent/ResourceUsageProgress.tsx
+++ b/plugins/openshift/src/components/DeploymentsListComponent/ResourceUsageProgress.tsx
@@ -6,7 +6,7 @@ import { Card, CardContent, Typography } from '@material-ui/core';
 
 const ResourceUsageProgress = (resourceInfo: any) => {
   const resourceType = resourceInfo.resourceType;
-  const usage = resourceInfo.resourceUsage[resourceType];
+  let usage = resourceInfo.resourceUsage[resourceType];
 
   const isUndefined = resourceInfo.resourceLimitsRequests.requests.undefined
 
@@ -17,6 +17,17 @@ const ResourceUsageProgress = (resourceInfo: any) => {
   const requests = resourceInfo.resourceLimitsRequests.requests
     ? resourceInfo?.resourceLimitsRequests?.requests[resourceType]
     : 0;
+
+  const convertNanocoresToCores = (value: number) => {
+    return value / 1000000000
+  };
+
+  // cpu utilization is in nanocores
+  if (resourceInfo.resourceType === 'cpu') {
+    usage = convertNanocoresToCores(usage)
+  }
+
+  const usagePercentageOfRequests = Math.min((usage / requests) * 100, 100);
 
   // Bar color is green by default
   let barColor = '#228B22';
@@ -44,17 +55,13 @@ const ResourceUsageProgress = (resourceInfo: any) => {
     },
   }))(LinearProgress);
 
-  const usagePercentageOfRequests = Math.min((usage / requests) * 100, 100);
-
   const formatResourceValue = (value: number) => {
     if (resourceInfo.resourceType === 'memory') {
       return `${value.toFixed(2)} Mi`;
     }
-    return `${value.toFixed(2)} cores`;
+    
+    return `${value} cores`;
   };
-
-  
-
 
   const ToolTipContent = () => {
     return (

--- a/plugins/openshift/src/components/DeploymentsListComponent/ResourceUsageProgress.tsx
+++ b/plugins/openshift/src/components/DeploymentsListComponent/ResourceUsageProgress.tsx
@@ -24,7 +24,7 @@ const ResourceUsageProgress = (resourceInfo: any) => {
 
   // cpu utilization is in nanocores
   if (resourceInfo.resourceType === 'cpu') {
-    usage = convertNanocoresToCores(usage)
+    usage = convertNanocoresToCores(usage).toFixed(6)
   }
 
   const usagePercentageOfRequests = Math.min((usage / requests) * 100, 100);


### PR DESCRIPTION
Nanocores was being divided by cores which lead to an extremely high value for cores used by any given deployment. 